### PR TITLE
Build and add APK to repository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,10 +63,12 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation("com.google.android.material:material:1.11.0")
 
     // Hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
     // Retrofit
     implementation(libs.retrofit)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
This commit includes the following changes:

- Built the release APK for the Ollama-lite Android application.
- Added the generated APK (`ollama-lite.apk`) to the root of the repository.
- Added a `gradle.properties` file to enable AndroidX and Jetifier.
- Added dependencies for Material Components and Hilt navigation to fix build errors.