### PR TITLE
feat: Add release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,29 @@ Build & Run
 4. Run on device/emulator.
 
 
+---
+
+Creating a Release
+
+This project includes a `release.sh` script to automate the process of building the APK and creating a GitHub release.
+
+**Prerequisites:**
+
+*   **GitHub CLI (`gh`):** You must have the GitHub CLI installed. You can find installation instructions at [cli.github.com](https://cli.github.com).
+*   **GitHub Token:** You must have a GitHub Personal Access Token with `repo` scope. This token should be exported as an environment variable named `GITHUB_TOKEN`.
+    ```bash
+    export GITHUB_TOKEN=your_github_token_here
+    ```
+
+**Usage:**
+
+To create a new release, run the script with a version tag:
+
+```bash
+./release.sh v1.0.0
+```
+
+The script will then build the debug APK, create a new release on GitHub with the specified tag, and upload the APK as a release asset.
 
 
 ---

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Configuration ---
+APK_PATH="app/build/outputs/apk/debug/app-debug.apk"
+
+# --- Helper functions ---
+function check_deps() {
+  if ! command -v gh &> /dev/null; then
+    echo "GitHub CLI (gh) could not be found. Please install it to continue."
+    exit 1
+  fi
+  if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN environment variable is not set. Please set it to your GitHub personal access token."
+    exit 1
+  fi
+}
+
+function build_apk() {
+  echo "Building the APK..."
+  export HOME=$(realpath ~)
+  export ANDROID_SDK_ROOT="$HOME/Android/sdk"
+  export ANDROID_HOME="$ANDROID_SDK_ROOT"
+  export PATH="$PATH:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+  export PATH="$PATH:$ANDROID_SDK_ROOT/platform-tools"
+  export PATH="$PATH:$ANDROID_SDK_ROOT/build-tools/35.0.1"
+  gradle assembleDebug
+  echo "Build complete."
+}
+
+function create_release() {
+  local version_tag=$1
+  echo "Creating GitHub release for tag $version_tag..."
+  gh release create "$version_tag" \
+    --title "Release $version_tag" \
+    --notes "Release for version $version_tag." \
+    "$APK_PATH"
+  echo "Release created successfully."
+}
+
+# --- Main script ---
+function main() {
+  if [ -z "$1" ]; then
+    echo "Usage: $0 <version-tag>"
+    echo "Example: $0 v1.0.0"
+    exit 1
+  fi
+
+  local version_tag=$1
+
+  check_deps
+  build_apk
+  create_release "$version_tag"
+}
+
+main "$@"


### PR DESCRIPTION
This commit introduces a new `release.sh` script to automate the process of building the Android application and creating a GitHub release.

The script performs the following actions:
- Checks for necessary dependencies (GitHub CLI).
- Verifies the presence of a `GITHUB_TOKEN` environment variable.
- Builds the debug APK using Gradle.
- Creates a new GitHub release with the generated APK as an asset.

The `README.md` has been updated to include instructions on how to use this new script, including the prerequisites and an example command.